### PR TITLE
Archive Tree Directories structure (dir - subdir)

### DIFF
--- a/src/fs/bra_fs.cpp
+++ b/src/fs/bra_fs.cpp
@@ -122,7 +122,7 @@ bool dir_isSubDir(const std::filesystem::path& base, const std::filesystem::path
         return false;
     }
 
-    // This is requires so it will check if it is relative as a parent
+    // This is required: it checks if it is relative subdir from parent
     if (!try_sanitize(p))
         return false;
 

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -148,6 +148,7 @@ static bool _bra_io_file_ctx_write_meta_file_process_write_dir(bra_io_file_ctx_t
         const bool replacing_dir = BRA_ATTR_TYPE(mf->attributes) == BRA_ATTR_TYPE_SUBDIR;    // bra_fs_dir_is_sub_dir(ctx->last_dir, dirname);
         if (replacing_dir)
         {
+            // TODO: here after dir-tree should be unreachable.
             bra_log_debug("parent dir %s is empty, replacing it with %s", ctx->last_dir, dirname);
             // mf->attributes.attr &= ~BRA_ATTR_TYPE(0xFF);           // clear the bits first
             // mf->attributes.attr |= BRA_ATTR_TYPE(BRA_ATTR_TYPE_DIR);    // in this case it becomes a regular dir
@@ -368,7 +369,10 @@ bool bra_io_file_ctx_read_meta_file(bra_io_file_ctx_t* ctx, bra_meta_file_t* mf)
     switch (BRA_ATTR_TYPE(mf->attributes))
     {
     case BRA_ATTR_TYPE_SUBDIR:
-        // TODO: for now as normal BRA_ATTR_TYPE_DIR.
+        // TODO
+        bra_log_critical("subdir read not implemented yet");
+        return false;
+        break;
     case BRA_ATTR_TYPE_DIR:
     {
         // NOTE: for directory doesn't have data-size nor data,
@@ -462,7 +466,10 @@ bool bra_io_file_ctx_write_meta_file(bra_io_file_ctx_t* ctx, bra_meta_file_t* mf
     }
     break;
     case BRA_ATTR_TYPE_SUBDIR:
-        // TODO: for now same as dir
+        // TODO
+        bra_log_critical("tree subdir write not implemented yet");
+        return false;
+        break;
     case BRA_ATTR_TYPE_DIR:
     {
         if (!_bra_io_file_ctx_write_meta_file_process_write_dir(ctx, mf, buf, &buf_size))
@@ -596,6 +603,12 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
     break;
     case BRA_ATTR_TYPE_SUBDIR:
         // TODO: for now like dir
+        // This i think genuinely should be like dir,
+        // unless for the build up tree ...
+        // so need to read the parent index
+        bra_log_critical("tree subdir decode not implemented yet");
+        return false;
+        break;
     case BRA_ATTR_TYPE_DIR:
     {
         if (bra_fs_dir_exists(mf.name))


### PR DESCRIPTION
- [ ] implement the functions related to the attrib subdir.
- [ ] also patch the attrib dir for the tree lookup when encoding and decoding

the tree lookup is basically an array of dir strings. The challenge is the only known thing is total files.

so i have to create an array of char* for all the entries even if it could be just the upper bound. to have an optimality on it, must be doing 2 passes: first count all the dir while scanning the filesystem, and then do the encoding, this is anyway not optimal as it is slower to do twice the filesystem calls rather than occupy eventually (almost all the cases as no one would like to store only directories)  more tree elements than needed. as it is a an array of pointers must also alloc the string there after,
need a library component to deal just with this operation:

- [ ] implement the tree array data structure separately.

------