### PR TITLE
Add checksum encoding/decoding verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(lib_bra STATIC src/lib_bra.c)
 target_sources(lib_bra
     PRIVATE
         src/lib_bra_private.c
+        src/lib_bra_crc32c.c
 
         src/log/bra_log.c
 

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
     "dictionaryDefinitions": [],
     "dictionaries": [],
     "words": [
+        "Castagnoli",
         "COMDAT",
         "ctest",
         "DCMAKE",

--- a/src/bra_tree_dir.c
+++ b/src/bra_tree_dir.c
@@ -113,7 +113,7 @@ static bra_tree_node_t* _bra_tree_dir_add_child_node(bra_tree_dir_t* tree, bra_t
 
 ////////////////////////////////////////////////////////////////////
 
-#ifndef NDEBUG
+#if 0
 void bra_tree_node_print(const bra_tree_node_t* node)
 {
     while (node != NULL)

--- a/src/bra_tree_dir.c
+++ b/src/bra_tree_dir.c
@@ -113,14 +113,14 @@ static bra_tree_node_t* _bra_tree_dir_add_child_node(bra_tree_dir_t* tree, bra_t
 
 ////////////////////////////////////////////////////////////////////
 
-#if 0
-void bra_tree_node_print(const bra_tree_node_t* node)
+#ifndef NDEBUG
+void bra_tree_node_log_verbose(const bra_tree_node_t* node)
 {
     while (node != NULL)
     {
-        bra_log_debug("tree: [%u] %s", node->index, node->dirname);
+        bra_log_verbose("tree: [%u] %s", node->index, node->dirname);
 
-        bra_tree_node_print(node->firstChild);
+        bra_tree_node_log_verbose(node->firstChild);
 
         node = node->next;
     }

--- a/src/bra_tree_dir.h
+++ b/src/bra_tree_dir.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #define BRA_TREE_NODE_ROOT_INDEX 0
 
-#ifndef NDEBUG
+#if 0
 /**
  * @brief Print the tree starting from @p node.
  *

--- a/src/bra_tree_dir.h
+++ b/src/bra_tree_dir.h
@@ -13,13 +13,13 @@ extern "C" {
 
 #define BRA_TREE_NODE_ROOT_INDEX 0
 
-#if 0
+#ifndef NDEBUG
 /**
  * @brief Print the tree starting from @p node.
  *
  * @param node
  */
-void bra_tree_node_print(const bra_tree_node_t* node);
+void bra_tree_node_log_verbose(const bra_tree_node_t* node);
 #endif
 
 /**

--- a/src/fs/bra_fs.cpp
+++ b/src/fs/bra_fs.cpp
@@ -468,7 +468,10 @@ bool search(const std::filesystem::path& dir, const std::string& pattern, std::l
                     continue;
                 }
 
-                bra_log_debug("Matched dir: %s", ep.string().c_str());
+#ifndef NDEBUG
+                bra_log_verbose("Matched dir: %s", ep.string().c_str());
+#endif
+
                 // out_files.push_back(ep);    // but if it is not a wildcard match it shouldn't be added.
                 if (!search(ep, pattern, out_files, recursive))
                     return false;

--- a/src/io/lib_bra_io_file.c
+++ b/src/io/lib_bra_io_file.c
@@ -277,10 +277,11 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset)
     return true;
 }
 
-bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const uint64_t data_size)
+bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me)
 {
     assert_bra_io_file_t(dst);
     assert_bra_io_file_t(src);
+    assert(me != NULL);
 
     char buf[BRA_MAX_CHUNK_SIZE];
 
@@ -295,6 +296,8 @@ bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const 
             bra_io_file_close(dst);
             return false;
         }
+
+        me->crc32 = bra_crc32c(buf, s, me->crc32);
 
         // write source chunk
         if (fwrite(buf, sizeof(char), s, dst->f) != s)

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -163,7 +163,7 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
  * @param dst
  * @param src
  * @param data_size
- * @param me        passed to compute the CRC32 of the file content.
+ * @param me        passed to compute the CRC32C of the file content and not @c NULL.
  * @retval true
  * @retval false
  */

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -163,7 +163,7 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
  * @param dst
  * @param src
  * @param data_size
- * @param me        passed to compute the CRC32C of the file content and not @c NULL.
+ * @param me        passed to compute the CRC32C of the file content, not @c NULL and @p me->crc32 is updated.
  * @retval true
  * @retval false
  */

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -163,10 +163,11 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
  * @param dst
  * @param src
  * @param data_size
+ * @param me        passed to compute the CRC32 of the file content.
  * @retval true
  * @retval false
  */
-bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const uint64_t data_size);
+bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me);
 
 /**
  * @brief Move @p f forward of @p data_size bytes.

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -86,9 +86,10 @@ static bool _bra_compute_header_crc32(const size_t filename_len, const char* fil
         return false;
     }
 
+    const uint16_t filename_len_u16 = (uint16_t) filename_len;
 
     me->crc32 = bra_crc32c(&me->attributes, sizeof(bra_attr_t), BRA_CRC32C_INIT);
-    me->crc32 = bra_crc32c(&filename_len, sizeof(uint16_t), me->crc32);
+    me->crc32 = bra_crc32c(&filename_len_u16, sizeof(uint16_t), me->crc32);
     me->crc32 = bra_crc32c(filename, filename_len, me->crc32);
 
     return true;
@@ -808,7 +809,7 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
         // compare CRC32
         if (read_crc32 != me.crc32)
         {
-            bra_log_critical("%s checksum failed!!!", me.name);
+            bra_log_critical("%s checksum failed!!!", fn);
             goto BRA_IO_DECODE_ERR;
         }
     }

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -75,7 +75,7 @@ static char* _bra_io_file_ctx_reconstruct_meta_entry_name(bra_io_file_ctx_t* ctx
     return NULL;
 }
 
-static uint32_t _bra_compute_common_crc32_3(const bra_attr_t attributes, const uint16_t name_size, const char* name)
+static uint32_t _bra_compute_header_crc32_3(const bra_attr_t attributes, const uint16_t name_size, const char* name)
 {
     assert(name != NULL);
     assert(name_size > 0);
@@ -89,7 +89,7 @@ static uint32_t _bra_compute_common_crc32_3(const bra_attr_t attributes, const u
     return crc32;
 }
 
-static bool _bra_compute_common_crc32_2(const bra_attr_t attributes, const char* name, uint32_t* out_crc32)
+static bool _bra_compute_header_crc32_2(const bra_attr_t attributes, const char* name, uint32_t* out_crc32)
 {
     assert(name != NULL);
     assert(out_crc32 != NULL);
@@ -102,7 +102,7 @@ static bool _bra_compute_common_crc32_2(const bra_attr_t attributes, const char*
     }
 
     const uint16_t name_size = (uint16_t) name_len;
-    *out_crc32               = _bra_compute_common_crc32_3(attributes, name_size, name);
+    *out_crc32               = _bra_compute_header_crc32_3(attributes, name_size, name);
     return true;
 }
 
@@ -122,7 +122,7 @@ static bool _bra_compute_header_crc32(const size_t filename_len, const char* fil
         bra_log_critical("filename %s too long %zu", filename, filename_len);
         return false;
     }
-    me->crc32 = _bra_compute_common_crc32_3(me->attributes, (uint16_t) filename_len, filename);
+    me->crc32 = _bra_compute_header_crc32_3(me->attributes, (uint16_t) filename_len, filename);
     return true;
 }
 
@@ -368,7 +368,7 @@ static bool _bra_io_file_ctx_write_meta_entry_dir_subdir(bra_io_file_ctx_t* ctx,
     if (!bra_meta_entry_init(me, attributes, node->dirname, node_dirname_len))
         return false;
 
-    if (!_bra_compute_common_crc32_2(attributes, dirname, &me->crc32))
+    if (!_bra_compute_header_crc32_2(attributes, dirname, &me->crc32))
         return false;
 
     if (BRA_ATTR_TYPE(me->attributes) == BRA_ATTR_TYPE_SUBDIR)

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -243,9 +243,17 @@ static bool _bra_io_file_ctx_write_meta_entry_process_write_file(bra_io_file_ctx
         return false;
     }
 
+    // double check
+    if (l > 0 && memcmp(ctx->last_dir, filename, l) != 0)
+    {
+        bra_log_critical("filename %s not belonging to dir %s", filename, ctx->last_dir);
+        return false;
+    }
+
+
     if (filename[l] == BRA_DIR_DELIM[0])    // or when l == 0
         ++l;                                // skip also '/'
-    else if (ctx->last_dir_size > 0)
+    else if (l > 0)
     {
         bra_log_critical("me->name: %s -- last_dir: %s", filename, ctx->last_dir);
         return false;

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -86,6 +86,7 @@ static bool _bra_compute_header_crc32(const size_t filename_len, const char* fil
         return false;
     }
 
+
     me->crc32 = bra_crc32c(&me->attributes, sizeof(bra_attr_t), BRA_CRC32C_INIT);
     me->crc32 = bra_crc32c(&filename_len, sizeof(uint16_t), me->crc32);
     me->crc32 = bra_crc32c(filename, filename_len, me->crc32);

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -620,9 +620,10 @@ bool bra_io_file_ctx_write_meta_entry(bra_io_file_ctx_t* ctx, const bra_attr_t a
 
     if (fwrite(&me.crc32, sizeof(uint32_t), 1, ctx->f.f) != 1)
         goto BRA_IO_WRITE_ERR;
-    // fflush(ctx->f.f);
 
+#ifndef NDEBUG
     bra_log_debug("%s CRC32 %08X", fn, me.crc32);
+#endif
 
     bra_meta_entry_free(&me);
     return true;
@@ -756,18 +757,15 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
         break;
     }
 
-    bra_log_debug("%s tell %llu", me.name, bra_io_file_tell(&ctx->f));
     // read CRC32
     uint32_t read_crc32;
     if (fread(&read_crc32, sizeof(uint32_t), 1, ctx->f.f) != 1)
         return false;
-    bra_log_debug("%s read crc32 %08x", me.name, read_crc32);
 
     // compare CRC32
     if (read_crc32 != me.crc32)
     {
         bra_log_critical("%s checksum failed!!!", me.name);
-        bra_log_debug("read_crc32=0x%08X  computed_crc32=0x%08X", read_crc32, me.crc32);
         return false;
     }
 

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -97,7 +97,7 @@ static bool _bra_compute_common_crc32_2(const bra_attr_t attributes, const char*
     const size_t name_len = strlen(name);
     if (name_len > UINT16_MAX)
     {
-        bra_log_critical("entry-name %s too long %zu", name, name_len);
+        bra_log_critical("full entry-name %s too long %zu", name, name_len);
         return false;
     }
 
@@ -233,7 +233,7 @@ static bool _bra_io_file_ctx_write_meta_entry_process_write_file(bra_io_file_ctx
 
     const size_t filename_len = strlen(filename);
     size_t       l            = ctx->last_dir_size;    // strnlen(g_last_dir, BRA_MAX_PATH_LENGTH);
-    if (l > filename)
+    if (l > filename_len)
     {
         bra_log_critical("last cached dir %s is not a prefix of filename %s: last_dir_size=%zu filename_len=%zu",
                          ctx->last_dir,
@@ -730,7 +730,7 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
 
     if (fn_len > UINT16_MAX)
     {
-        bra_log_critical("entry-name %s too long %zu", fn, fn_len);
+        bra_log_critical("full entry-name %s too long %zu", fn, fn_len);
         goto BRA_IO_DECODE_ERR;
     }
 

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -620,7 +620,7 @@ bool bra_io_file_ctx_write_meta_entry(bra_io_file_ctx_t* ctx, const bra_attr_t a
 
     if (fwrite(&me.crc32, sizeof(uint32_t), 1, ctx->f.f) != 1)
         goto BRA_IO_WRITE_ERR;
-    fflush(ctx->f.f);
+    // fflush(ctx->f.f);
 
     bra_log_debug("%s CRC32 %08X", fn, me.crc32);
 
@@ -705,7 +705,8 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
         else
         {
             bra_io_file_t f2;
-            end_msg = g_end_messages[0];
+            end_msg  = g_end_messages[0];
+            me.crc32 = bra_crc32c(&mef->data_size, sizeof(uint64_t), me.crc32);
             bra_log_printf("Extracting file: " BRA_PRINTF_FMT_FILENAME, fn);
             // NOTE: the directory must have been created in the previous entry,
             //       otherwise this will fail to create the file.

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -233,7 +233,7 @@ static bool _bra_io_file_ctx_read_meta_entry_read_subdir(bra_io_file_ctx_t* ctx,
 /**
  * @brief
  *
- * @note @pe must be free either on error or success by the caller.
+ * @note @p me must be free either on error or success by the caller.
  *
  * @param ctx
  * @param attributes

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -78,9 +78,14 @@ static char* _bra_io_file_ctx_reconstruct_meta_entry_name(bra_io_file_ctx_t* ctx
 static uint32_t _bra_compute_header_crc32_3(const bra_attr_t attributes, const uint16_t name_size, const char* name)
 {
     assert(name != NULL);
-    assert(name_size > 0);
 
     uint32_t crc32;
+
+    if (name_size == 0)
+    {
+        bra_log_critical("empty entry-name");
+        return false;
+    }
 
     crc32 = bra_crc32c(&attributes, sizeof(bra_attr_t), BRA_CRC32C_INIT);
     crc32 = bra_crc32c(&name_size, sizeof(uint16_t), crc32);
@@ -97,7 +102,7 @@ static bool _bra_compute_header_crc32_2(const bra_attr_t attributes, const char*
     const size_t name_len = strlen(name);
     if (name_len > UINT16_MAX)
     {
-        bra_log_critical("full entry-name %s too long %zu", name, name_len);
+        bra_log_critical("full entry-name '%s' too long or empty %zu", name, name_len);
         return false;
     }
 
@@ -111,17 +116,12 @@ static bool _bra_compute_header_crc32(const size_t filename_len, const char* fil
     assert(filename != NULL);
     assert(me != NULL);
 
-    if (filename_len == 0)
-    {
-        bra_log_critical("empty filename");
-        return false;
-    }
-
     if (filename_len > UINT16_MAX)
     {
         bra_log_critical("filename %s too long %zu", filename, filename_len);
         return false;
     }
+
     me->crc32 = _bra_compute_header_crc32_3(me->attributes, (uint16_t) filename_len, filename);
     return true;
 }

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -257,12 +257,12 @@ static bool _bra_io_file_ctx_read_meta_entry_subdir(bra_io_file_ctx_t* ctx, bra_
  *
  * @note @p me must be free either on error or success by the caller.
  *
- * @param ctx
- * @param attributes
- * @param filename
- * @param me        Provided by caller; this function initializes/populates it.
- * @retval true     On success.
- * @retval false    on error.
+ * @param ctx        Archive file context
+ * @param attributes File attributes
+ * @param filename   File name (full path)
+ * @param me         Provided by caller; this function initializes/populates it.
+ * @retval true      On success.
+ * @retval false     On error.
  */
 static bool _bra_io_file_ctx_write_meta_entry_file(bra_io_file_ctx_t* ctx, const bra_attr_t attributes, const char* filename, bra_meta_entry_t* me)
 {

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -82,7 +82,7 @@ static bool _bra_compute_header_crc32_3(const bra_attr_t attributes, const uint1
 
     if (name_size == 0)
     {
-        bra_log_critical("empty entry-name");
+        bra_log_critical("empty entry name_size");
         return false;
     }
 
@@ -101,7 +101,7 @@ static bool _bra_compute_header_crc32_2(const bra_attr_t attributes, const char*
     const size_t name_len = strlen(name);
     if (name_len > UINT16_MAX)
     {
-        bra_log_critical("full entry-name '%s' too long or empty %zu", name, name_len);
+        bra_log_critical("full entry-name '%s' too long%zu", name, name_len);
         return false;
     }
 
@@ -116,7 +116,7 @@ static bool _bra_compute_header_crc32(const size_t filename_len, const char* fil
 
     if (filename_len > UINT16_MAX)
     {
-        bra_log_critical("filename %s too long %zu", filename, filename_len);
+        bra_log_critical("filename '%s' too long %zu", filename, filename_len);
         return false;
     }
 

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -435,10 +435,9 @@ bool bra_io_file_ctx_close(bra_io_file_ctx_t* ctx)
     if (ctx->tree != NULL)
     {
 
-#if 0
-// #ifndef NDEBUG
-        // print the tree
-        bra_tree_node_print(ctx->tree->root);
+#ifndef NDEBUG
+        // print the tree (verbose level)
+        bra_tree_node_log_verbose(ctx->tree->root);
 #endif
 
         bra_tree_dir_destroy(&ctx->tree);
@@ -654,7 +653,7 @@ bool bra_io_file_ctx_write_meta_entry(bra_io_file_ctx_t* ctx, const bra_attr_t a
         goto BRA_IO_WRITE_ERR;
 
 #ifndef NDEBUG
-    bra_log_debug("%s CRC32 %08X", fn, me.crc32);
+    bra_log_verbose("%s CRC32 %08X", fn, me.crc32);
 #endif
 
     bra_meta_entry_free(&me);

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -211,12 +211,14 @@ static bool _bra_io_file_ctx_read_meta_entry_read_subdir(bra_io_file_ctx_t* ctx,
 /**
  * @brief
  *
+ * @note @pe must be free either on error or success by the caller.
+ *
  * @param ctx
  * @param attributes
  * @param filename
- * @param me        it is allocated here and must be free by the callee.
- * @retval true     On success. @p me is allocated and must be freed.
- * @retval false    on error. It frees @p me
+ * @param me        Provided by caller; this function initializes/populates it.
+ * @retval true     On success.
+ * @retval false    on error.
  */
 static bool _bra_io_file_ctx_write_meta_entry_process_write_file(bra_io_file_ctx_t* ctx, const bra_attr_t attributes, const char* filename, bra_meta_entry_t* me)
 {
@@ -289,12 +291,14 @@ static bool _bra_io_file_ctx_write_meta_entry_process_write_file(bra_io_file_ctx
 /**
  * @brief
  *
+ * @note @pe must be free either on error or success by the caller.
+ *
  * @param ctx
  * @param attributes
  * @param dirname
- * @param me         it is allocated here and must be free by the callee.
- * @retval true      On success. @p me is allocated and must be freed.
- * @retval false     on error. It frees @p me
+ * @param me         Provided by caller; this function initializes/populates it.
+ * @retval true      On success.
+ * @retval false     on error.
  */
 static bool _bra_io_file_ctx_write_meta_entry_process_write_dir_subdir(bra_io_file_ctx_t* ctx, bra_attr_t attributes, const char* dirname, bra_meta_entry_t* me)
 {

--- a/src/io/lib_bra_io_file_ctx.h
+++ b/src/io/lib_bra_io_file_ctx.h
@@ -32,7 +32,7 @@ bool bra_io_file_ctx_open(bra_io_file_ctx_t* ctx, const char* fn, const char* mo
 bool bra_io_file_ctx_sfx_open(bra_io_file_ctx_t* ctx, const char* fn, const char* mode);
 
 /**
- * @brief
+ * @brief Close the file associated with @p ctx and free any allocated resources.
  *
  * @param ctx
  * @retval true
@@ -99,6 +99,26 @@ bool bra_io_file_ctx_read_meta_entry(bra_io_file_ctx_t* ctx, bra_meta_entry_t* m
  * @retval false on error closes @p ctx->f via @ref bra_io_file_close.
  */
 bool bra_io_file_ctx_write_meta_entry(bra_io_file_ctx_t* ctx, const bra_attr_t attributes, const char* fn);
+
+/**
+ * @brief
+ *
+ * @param ctx
+ * @param mef
+ * @return true
+ * @return false
+ */
+bool bra_io_file_ctx_read_meta_entry_footer(bra_io_file_ctx_t* ctx, bra_meta_entry_footer_t* mef);
+
+/**
+ * @brief
+ *
+ * @param ctx
+ * @param mef
+ * @return true
+ * @return false
+ */
+bool bra_io_file_ctx_write_meta_entry_footer(bra_io_file_ctx_t* ctx, const bra_meta_entry_footer_t* mef);
 
 /**
  * @brief Encode a file or directory @p fn and append it to the open archive @p ctx->f.

--- a/src/io/lib_bra_io_file_ctx.h
+++ b/src/io/lib_bra_io_file_ctx.h
@@ -101,26 +101,6 @@ bool bra_io_file_ctx_read_meta_entry(bra_io_file_ctx_t* ctx, bra_meta_entry_t* m
 bool bra_io_file_ctx_write_meta_entry(bra_io_file_ctx_t* ctx, const bra_attr_t attributes, const char* fn);
 
 /**
- * @brief
- *
- * @param ctx
- * @param mef
- * @return true
- * @return false
- */
-bool bra_io_file_ctx_read_meta_entry_footer(bra_io_file_ctx_t* ctx, bra_meta_entry_footer_t* mef);
-
-/**
- * @brief
- *
- * @param ctx
- * @param mef
- * @return true
- * @return false
- */
-bool bra_io_file_ctx_write_meta_entry_footer(bra_io_file_ctx_t* ctx, const bra_meta_entry_footer_t* mef);
-
-/**
  * @brief Encode a file or directory @p fn and append it to the open archive @p ctx->f.
  *        On error closes @p ctx->f via @ref bra_io_file_close.
  *

--- a/src/lib_bra.c
+++ b/src/lib_bra.c
@@ -110,7 +110,7 @@ bool bra_meta_entry_init(bra_meta_entry_t* me, const bra_attr_t attr, const char
     else
         me->name = NULL;
 
-    me->crc32 = BRA_CRC32_INIT;
+    me->crc32 = BRA_CRC32C_INIT;
     return true;
 }
 

--- a/src/lib_bra.c
+++ b/src/lib_bra.c
@@ -125,6 +125,7 @@ void bra_meta_entry_free(bra_meta_entry_t* me)
     }
     me->name_size  = 0;
     me->attributes = 0;
+    me->crc32      = 0;
     if (me->name != NULL)
     {
         free(me->name);

--- a/src/lib_bra.c
+++ b/src/lib_bra.c
@@ -110,6 +110,7 @@ bool bra_meta_entry_init(bra_meta_entry_t* me, const bra_attr_t attr, const char
     else
         me->name = NULL;
 
+    me->crc32 = BRA_CRC32_INIT;
     return true;
 }
 

--- a/src/lib_bra.h
+++ b/src/lib_bra.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <lib_bra_defs.h>
 #include <lib_bra_types.h>
+#include <lib_bra_crc32c.h>
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/lib_bra_crc32c.c
+++ b/src/lib_bra_crc32c.c
@@ -1,12 +1,21 @@
 #include <lib_bra_crc32c.h>
 
-uint32_t bra_crc32c(const uint8_t* data, const size_t length, const uint32_t previous_crc)
+#include <log/bra_log.h>
+
+uint32_t bra_crc32c(const void* data, const uint64_t length, const uint32_t previous_crc)
 {
+    if (length == UINT64_MAX)
+    {
+        bra_log_warn("CRC32 encoding length invalid, split in half...");
+        uint32_t crc = bra_crc32c(data, length / 2, previous_crc);
+        return bra_crc32c(&((uint8_t*) data)[length / 2], length - (length / 2), crc);
+    }
+
     uint32_t crc = ~previous_crc;    // Invert initial CRC value
 
-    for (size_t i = 0; i < length; i++)
+    for (uint64_t i = 0; i < length; i++)
     {
-        uint8_t byte  = data[i];
+        uint8_t byte  = ((uint8_t*) data)[i];
         crc          ^= byte;          // XOR byte into the least significant byte of CRC
 
         for (int j = 0; j < 8; j++)    // Process each bit

--- a/src/lib_bra_crc32c.c
+++ b/src/lib_bra_crc32c.c
@@ -12,18 +12,16 @@ uint32_t bra_crc32c(const void* data, const uint64_t length, const uint32_t prev
     }
 
     uint32_t crc = ~previous_crc;    // Invert initial CRC value
-
-    for (uint64_t i = 0; i < length; i++)
+    for (uint64_t i = 0; i < length; ++i)
     {
-        uint8_t byte  = ((uint8_t*) data)[i];
-        crc          ^= byte;          // XOR byte into the least significant byte of CRC
-
-        for (int j = 0; j < 8; j++)    // Process each bit
+        const uint8_t byte  = ((uint8_t*) data)[i];
+        crc                ^= byte;    // XOR byte into the least significant byte of CRC
+        for (int j = 0; j < 8; ++j)    // Process each bit
         {
             if (crc & 1)
-                crc = (crc >> 1) ^ BRA_CRC32_INIT;    // Apply polynomial if LSB is 1
+                crc = (crc >> 1) ^ BRA_CRC32C_POLY;    // Apply polynomial if LSB is 1
             else
-                crc >>= 1;                            // Just shift if LSB is 0
+                crc >>= 1;                             // Just shift if LSB is 0
         }
     }
 

--- a/src/lib_bra_crc32c.c
+++ b/src/lib_bra_crc32c.c
@@ -7,7 +7,7 @@ uint32_t bra_crc32c(const void* data, const uint64_t length, const uint32_t prev
     uint32_t crc = ~previous_crc;    // Invert initial CRC value
     for (uint64_t i = 0; i < length; ++i)
     {
-        const uint8_t byte  = ((uint8_t*) data)[i];
+        const uint8_t byte  = ((const uint8_t*) data)[i];
         crc                ^= byte;    // XOR byte into the least significant byte of CRC
         for (int j = 0; j < 8; ++j)    // Process each bit
         {

--- a/src/lib_bra_crc32c.c
+++ b/src/lib_bra_crc32c.c
@@ -1,0 +1,22 @@
+#include <lib_bra_crc32c.h>
+
+uint32_t bra_crc32c(const uint8_t* data, const size_t length, const uint32_t previous_crc)
+{
+    uint32_t crc = ~previous_crc;    // Invert initial CRC value
+
+    for (size_t i = 0; i < length; i++)
+    {
+        uint8_t byte  = data[i];
+        crc          ^= byte;          // XOR byte into the least significant byte of CRC
+
+        for (int j = 0; j < 8; j++)    // Process each bit
+        {
+            if (crc & 1)
+                crc = (crc >> 1) ^ BRA_CRC32_INIT;    // Apply polynomial if LSB is 1
+            else
+                crc >>= 1;                            // Just shift if LSB is 0
+        }
+    }
+
+    return ~crc;    // Invert final CRC value
+}

--- a/src/lib_bra_crc32c.c
+++ b/src/lib_bra_crc32c.c
@@ -4,13 +4,6 @@
 
 uint32_t bra_crc32c(const void* data, const uint64_t length, const uint32_t previous_crc)
 {
-    if (length == UINT64_MAX)
-    {
-        bra_log_warn("CRC32 encoding length invalid, split in half...");
-        uint32_t crc = bra_crc32c(data, length / 2, previous_crc);
-        return bra_crc32c(&((uint8_t*) data)[length / 2], length - (length / 2), crc);
-    }
-
     uint32_t crc = ~previous_crc;    // Invert initial CRC value
     for (uint64_t i = 0; i < length; ++i)
     {

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -10,6 +10,8 @@
 /**
  * @brief Calculates the CRC32C (Castagnoli) checksum of the given data.
  *
+ * @todo this is very inefficient, replace with a table-based implementation and SSE4.2.
+ *
  * @param data         Pointer to the input data.
  * @param length       Length of the input data in bytes.
  * @param previous_crc Previous CRC value (for incremental updates).

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -6,7 +6,10 @@
  * @brief Initial value for CRC32C calculation.
  *        Polynomial for CRC32C (Castagnoli): 0x1EDC6F41
  */
-#define BRA_CRC32_INIT 0x1EDC6F41
+// #define BRA_CRC32_INIT      0xFFFFFFFF     // 0x1EDC6F41
+// #define BRA_CRC32C_POLY     0x1EDC6F41u    // CRC-32C (Castagnoli) polynomial
+#define BRA_CRC32C_INIT 0              // reflected initial value
+#define BRA_CRC32C_POLY 0x82F63B78u    // reflected CRC-32C (Castagnoli)
 
 /**
  * @brief Calculates the CRC32C (Castagnoli) checksum of the given data.

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Initial value for CRC32C calculation.
+ *        Polynomial for CRC32C (Castagnoli): 0x1EDC6F41
+ */
+#define BRA_CRC32_INIT 0x1EDC6F41
+
+/**
+ * @brief Calculates the CRC32C (Castagnoli) checksum of the given data.
+ *
+ * @param data         Pointer to the input data.
+ * @param length       Length of the input data.
+ * @param previous_crc Previous CRC value (for incremental updates).
+ * @return uint32_t    The calculated CRC32C checksum.
+ */
+uint32_t bra_crc32c(const uint8_t* data, const size_t length, const uint32_t previous_crc);

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -2,10 +2,6 @@
 
 #include <stdint.h>
 
-/**
- * @brief Initial value for CRC32C calculation.
- *        Polynomial for CRC32C (Castagnoli): 0x1EDC6F41
- */
 // #define BRA_CRC32_INIT      0xFFFFFFFF     // 0x1EDC6F41
 // #define BRA_CRC32C_POLY     0x1EDC6F41u    // CRC-32C (Castagnoli) polynomial
 #define BRA_CRC32C_INIT 0u             // reflected initial value

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -8,7 +8,7 @@
  */
 // #define BRA_CRC32_INIT      0xFFFFFFFF     // 0x1EDC6F41
 // #define BRA_CRC32C_POLY     0x1EDC6F41u    // CRC-32C (Castagnoli) polynomial
-#define BRA_CRC32C_INIT 0              // reflected initial value
+#define BRA_CRC32C_INIT 0u             // reflected initial value
 #define BRA_CRC32C_POLY 0x82F63B78u    // reflected CRC-32C (Castagnoli)
 
 /**

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -13,7 +13,6 @@
 
 /**
  * @brief Calculates the CRC32C (Castagnoli) checksum of the given data.
- *        If @p length is @c UINT64_MAX the function recursively call itself twice splitting the data in 2 halves.
  *
  * @param data         Pointer to the input data.
  * @param length       Length of the input data in bytes.

--- a/src/lib_bra_crc32c.h
+++ b/src/lib_bra_crc32c.h
@@ -10,10 +10,11 @@
 
 /**
  * @brief Calculates the CRC32C (Castagnoli) checksum of the given data.
+ *        If @p length is @c UINT64_MAX the function recursively call itself twice splitting the data in 2 halves.
  *
  * @param data         Pointer to the input data.
- * @param length       Length of the input data.
+ * @param length       Length of the input data in bytes.
  * @param previous_crc Previous CRC value (for incremental updates).
  * @return uint32_t    The calculated CRC32C checksum.
  */
-uint32_t bra_crc32c(const uint8_t* data, const size_t length, const uint32_t previous_crc);
+uint32_t bra_crc32c(const void* data, const uint64_t length, const uint32_t previous_crc);

--- a/src/lib_bra_types.h
+++ b/src/lib_bra_types.h
@@ -69,12 +69,13 @@ typedef struct bra_meta_entry_t
     uint8_t    name_size;     //!< length in bytes excluding the trailing NUL; [1..UINT8_MAX]
     char*      name;          //!< filename/dirname (owned; free via @ref bra_meta_entry_free)
     void*      entry_data;    //!< Type-specific entry data: file size for files, parent tree index for subdirs, NULL for dirs and symlinks. (owned; free via @ref bra_meta_entry_free)
+    uint32_t   crc32;         //!< CRC32C of the file data; 0 if not computed.
 } bra_meta_entry_t;
 
-typedef struct bra_meta_entry_footer_t
-{
-    uint32_t crc32;    //!< CRC32C of the file data; 0 if not computed.
-} bra_meta_entry_footer_t;
+// typedef struct bra_meta_entry_footer_t
+// {
+//     uint32_t crc32;
+// } bra_meta_entry_footer_t;
 
 /**
  * @brief Metadata for a file entry in a BR-archive.

--- a/src/lib_bra_types.h
+++ b/src/lib_bra_types.h
@@ -71,10 +71,16 @@ typedef struct bra_meta_entry_t
     void*      entry_data;    //!< Type-specific entry data: file size for files, parent tree index for subdirs, NULL for dirs and symlinks. (owned; free via @ref bra_meta_entry_free)
 } bra_meta_entry_t;
 
+typedef struct bra_meta_entry_footer_t
+{
+    uint32_t crc32;    //!< CRC32C of the file data; 0 if not computed.
+} bra_meta_entry_footer_t;
+
 /**
  * @brief Metadata for a file entry in a BR-archive.
  */
 typedef struct bra_meta_entry_file_t
+
 {
     uint64_t data_size;    //!< file contents size in bytes.
 } bra_meta_entry_file_t;

--- a/src/lib_bra_types.h
+++ b/src/lib_bra_types.h
@@ -68,8 +68,8 @@ typedef struct bra_meta_entry_t
     bra_attr_t attributes;    //!< file attributes: #BRA_ATTR_TYPE_FILE, #BRA_ATTR_TYPE_DIR, #BRA_ATTR_TYPE_SYMLINK, #BRA_ATTR_TYPE_SUBDIR
     uint8_t    name_size;     //!< length in bytes excluding the trailing NUL; [1..UINT8_MAX]
     char*      name;          //!< filename/dirname (owned; free via @ref bra_meta_entry_free)
-    void*      entry_data;    //!< Type-specific entry data: file size for files, parent tree index for subdirs, NULL for dirs and symlinks. (owned; free via @ref bra_meta_entry_free)
-    uint32_t   crc32;         //!< CRC32C of the file data; 0 if not computed.
+    void*      entry_data;    //!< Type-specific entry data: file size for files, parent tree index for subdirs, @c NULL for dirs and symlinks. (owned; free via @ref bra_meta_entry_free)
+    uint32_t   crc32;         //!< CRC32C of the entry data; written after all other values, even after the file content (last value of an entry).
 } bra_meta_entry_t;
 
 /**

--- a/src/lib_bra_types.h
+++ b/src/lib_bra_types.h
@@ -72,16 +72,10 @@ typedef struct bra_meta_entry_t
     uint32_t   crc32;         //!< CRC32C of the file data; 0 if not computed.
 } bra_meta_entry_t;
 
-// typedef struct bra_meta_entry_footer_t
-// {
-//     uint32_t crc32;
-// } bra_meta_entry_footer_t;
-
 /**
  * @brief Metadata for a file entry in a BR-archive.
  */
 typedef struct bra_meta_entry_file_t
-
 {
     uint64_t data_size;    //!< file contents size in bytes.
 } bra_meta_entry_file_t;

--- a/src/prog/bra.cpp
+++ b/src/prog/bra.cpp
@@ -40,7 +40,7 @@ private:
     int64_t                                m_header_offset     = -1;
     bool                                   m_sfx               = false;
     bool                                   m_recursive         = false;
-    uint8_t                                m_progress_width    = 0;
+    int                                    m_progress_width    = 0;
 
 
 protected:
@@ -254,6 +254,12 @@ protected:
 
         m_files.clear();
         m_progress_width = snprintf(nullptr, 0, "%u", m_tot_files);
+        if (m_progress_width < 0)
+        {
+            bra_log_critical("internal error");
+            return false;
+        }
+
         return true;
     };
 

--- a/src/prog/bra.cpp
+++ b/src/prog/bra.cpp
@@ -268,7 +268,7 @@ protected:
     {
         auto path = p;
 
-        // write Progress (+1 because it is the file that is going to be written nows)
+        // write Progress (+1 because it is the file that is going to be written now)
         // TODO: add progress bar?
         bra_log_printf("[%*u/%u] ", m_progress_width, m_written_num_files + 1, m_tot_files);
 

--- a/src/prog/bra.cpp
+++ b/src/prog/bra.cpp
@@ -16,6 +16,7 @@
 #include <map>
 
 #include <cstdint>
+#include <cstdio>
 
 
 using namespace std;

--- a/src/prog/bra.cpp
+++ b/src/prog/bra.cpp
@@ -254,7 +254,6 @@ protected:
 
         m_files.clear();
         m_progress_width = snprintf(nullptr, 0, "%u", m_tot_files);
-        bra_log_debug("Progress width: %u", m_progress_width);
         return true;
     };
 

--- a/src/prog/unbra.cpp
+++ b/src/prog/unbra.cpp
@@ -182,11 +182,11 @@ protected:
         bra_log_printf("%s contains num files: %u\n", m_ctx.f.fn, bh.num_files);
         if (m_listContent)
         {
-            bra_log_printf("| ATTR |   SIZE    | " BRA_PRINTF_FMT_FILENAME "|  CRC32  |\n", "FILENAME");
+            bra_log_printf("| ATTR |   SIZE    | " BRA_PRINTF_FMT_FILENAME "| CRC32  |\n", "FILENAME");
             bra_log_printf("|------|-----------|-");
             for (int i = 0; i < BRA_PRINTF_FMT_FILENAME_MAX_LENGTH; i++)
                 bra_log_printf("-");
-            bra_log_printf("|---------|\n");
+            bra_log_printf("|--------|\n");
             for (uint32_t i = 0; i < bh.num_files; i++)
             {
                 if (!bra_io_file_ctx_print_meta_entry(&m_ctx))

--- a/src/prog/unbra.cpp
+++ b/src/prog/unbra.cpp
@@ -182,11 +182,11 @@ protected:
         bra_log_printf("%s contains num files: %u\n", m_ctx.f.fn, bh.num_files);
         if (m_listContent)
         {
-            bra_log_printf("| ATTR |   SIZE    | " BRA_PRINTF_FMT_FILENAME "|\n", "FILENAME");
+            bra_log_printf("| ATTR |   SIZE    | " BRA_PRINTF_FMT_FILENAME "|  CRC32  |\n", "FILENAME");
             bra_log_printf("|------|-----------|-");
             for (int i = 0; i < BRA_PRINTF_FMT_FILENAME_MAX_LENGTH; i++)
                 bra_log_printf("-");
-            bra_log_printf("|\n");
+            bra_log_printf("|---------|\n");
             for (uint32_t i = 0; i < bh.num_files; i++)
             {
                 if (!bra_io_file_ctx_print_meta_entry(&m_ctx))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,13 @@ add_test(NAME test_bra_encoders.encode_decode_rle_3b COMMAND test_bra_encoders t
 
 #####################################################################################################
 
+add_executable(test_bra_crc32c test_bra_crc32c.cpp)
+target_link_libraries(test_bra_crc32c PUBLIC lib_bra)
+
+add_test(NAME test_bra_crc32c.compute_crc32  COMMAND test_bra_crc32c test_bra_crc32c_compute_crc32)
+
+#####################################################################################################
+
 
 # set_tests_properties(
 #     test_bra.no_output_file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,7 @@ add_test(NAME test_bra.bra_unbra_all                 COMMAND test_bra test_bra_u
 #####################################################################################################
 
 add_executable(test_bra_encoders test_bra_encoders.cpp)
-target_link_libraries(test_bra_encoders PUBLIC lib_bra)
+target_link_libraries(test_bra_encoders PRIVATE lib_bra)
 
 add_test(NAME test_bra_encoders.encode_decode_rle_1  COMMAND test_bra_encoders test_bra_encoders_encode_decode_rle_1)
 add_test(NAME test_bra_encoders.encode_decode_rle_2  COMMAND test_bra_encoders test_bra_encoders_encode_decode_rle_2)
@@ -85,10 +85,10 @@ add_test(NAME test_bra_encoders.encode_decode_rle_3b COMMAND test_bra_encoders t
 #####################################################################################################
 
 add_executable(test_bra_crc32c test_bra_crc32c.cpp)
-target_link_libraries(test_bra_crc32c PUBLIC lib_bra)
+target_link_libraries(test_bra_crc32c PRIVATE lib_bra)
 
 add_test(NAME test_bra_crc32c.compute_crc32  COMMAND test_bra_crc32c test_bra_crc32c_compute_crc32)
-
+add_test(NAME test_bra_crc32c.empty_input    COMMAND test_bra_crc32c test_bra_crc32c_empty_input)
 #####################################################################################################
 
 

--- a/test/test_bra_crc32c.cpp
+++ b/test/test_bra_crc32c.cpp
@@ -18,7 +18,7 @@ TEST(test_bra_crc32c_compute_crc32)
     ASSERT_EQ(bra_crc32c(data1, sizeof(data1) - 1, 0), 0xE3069283);
 
     uint32_t crc = bra_crc32c(data1, 5, BRA_CRC32C_INIT);    // "12345"
-    crc          = bra_crc32c(&data1[5], 4, crc);            // "s6789"
+    crc          = bra_crc32c(&data1[5], 4, crc);            // "6789"
     ASSERT_EQ(crc, 0xE3069283);
 
     return 0;

--- a/test/test_bra_crc32c.cpp
+++ b/test/test_bra_crc32c.cpp
@@ -1,0 +1,29 @@
+#include "bra_test.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+
+#include <lib_bra_crc32c.h>
+}
+#endif
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+TEST(test_bra_crc32c_compute_crc32)
+{
+    // CRC‑32C("123456789") = 0xE3069283.
+    constexpr char data1[] = "123456789";
+
+    ASSERT_EQ(bra_crc32c(data1, sizeof(data1) - 1, 0), 0xE3069283);
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    const std::map<std::string, std::function<int()>> m = {
+        {TEST_FUNC(test_bra_crc32c_compute_crc32)},
+    };
+
+    return test_main(argc, argv, m);
+}

--- a/test/test_bra_crc32c.cpp
+++ b/test/test_bra_crc32c.cpp
@@ -18,9 +18,6 @@ TEST(test_bra_crc32c_compute_crc32)
     ASSERT_EQ(bra_crc32c(data1, sizeof(data1) - 1, 0), 0xE3069283);
     ASSERT_EQ(bra_crc32c("", 0, BRA_CRC32C_INIT), BRA_CRC32C_INIT);
 
-    printf("All CRC-32C tests passed!\n");
-
-
     return 0;
 }
 

--- a/test/test_bra_crc32c.cpp
+++ b/test/test_bra_crc32c.cpp
@@ -16,8 +16,18 @@ TEST(test_bra_crc32c_compute_crc32)
     constexpr char data1[] = "123456789";
 
     ASSERT_EQ(bra_crc32c(data1, sizeof(data1) - 1, 0), 0xE3069283);
-    ASSERT_EQ(bra_crc32c("", 0, BRA_CRC32C_INIT), BRA_CRC32C_INIT);
 
+    uint32_t crc = bra_crc32c(data1, 5, BRA_CRC32C_INIT);    // "12345"
+    crc          = bra_crc32c(&data1[5], 4, crc);            // "s6789"
+    ASSERT_EQ(crc, 0xE3069283);
+
+    return 0;
+}
+
+TEST(test_bra_crc32c_empty_input)
+{
+    ASSERT_EQ(bra_crc32c("", 0, BRA_CRC32C_INIT), BRA_CRC32C_INIT);
+    ASSERT_EQ(bra_crc32c(nullptr, 0, BRA_CRC32C_INIT), BRA_CRC32C_INIT);
     return 0;
 }
 
@@ -25,6 +35,7 @@ int main(int argc, char* argv[])
 {
     const std::map<std::string, std::function<int()>> m = {
         {TEST_FUNC(test_bra_crc32c_compute_crc32)},
+        {TEST_FUNC(test_bra_crc32c_empty_input)},
     };
 
     return test_main(argc, argv, m);

--- a/test/test_bra_crc32c.cpp
+++ b/test/test_bra_crc32c.cpp
@@ -16,6 +16,11 @@ TEST(test_bra_crc32c_compute_crc32)
     constexpr char data1[] = "123456789";
 
     ASSERT_EQ(bra_crc32c(data1, sizeof(data1) - 1, 0), 0xE3069283);
+    ASSERT_EQ(bra_crc32c("", 0, BRA_CRC32C_INIT), BRA_CRC32C_INIT);
+
+    printf("All CRC-32C tests passed!\n");
+
+
     return 0;
 }
 


### PR DESCRIPTION
- [x] filename should crc the original filename not the one in the meta entry, the problem is must be a max size, i think `uint16_t` for filename size (more than 255 chars) should be enough for the full relative path. Besides: do i really need to encode them? well.. yes, but it would be enough only the file content.
- [x] encoding / decoding doesn't restore the origina path (bug)
- [x] based on the above bug: create a test to check that dirs are build correctly and restored correctly in (`bra_io_file_ctx_read_meta_entry`) [detached #105]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-entry CRC-32C checksums added; archive listings display a CRC32 column. Encoder shows a progress counter.

* **Refactor**
  * Adjusted logging verbosity and renamed internal debug helpers for clearer non-debug output.

* **Documentation**
  * Clarified documentation for closing file/context resources.

* **Chores**
  * Build now includes CRC-32C support; spell-check dictionary updated ("Castagnoli").

* **Tests**
  * Added unit tests and a test target for CRC-32C.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->