### PR TITLE
add unbra --test mode to test the archive

### DIFF
--- a/src/io/lib_bra_io_file.c
+++ b/src/io/lib_bra_io_file.c
@@ -359,5 +359,9 @@ bool bra_io_file_skip_data(bra_io_file_t* f, const uint64_t data_size)
 {
     assert_bra_io_file_t(f);
 
-    return bra_io_file_seek(f, data_size, SEEK_CUR);
+    const bool res = bra_io_file_seek(f, data_size, SEEK_CUR);
+    if (!res)
+        bra_io_file_seek_error(f);
+
+    return res;
 }

--- a/src/io/lib_bra_io_file.c
+++ b/src/io/lib_bra_io_file.c
@@ -285,6 +285,31 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset)
     return true;
 }
 
+bool bra_io_file_read_file_chunks(bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me)
+{
+    assert_bra_io_file_t(src);
+    assert(me != NULL);
+
+    char buf[BRA_MAX_CHUNK_SIZE];
+
+    for (uint64_t i = 0; i < data_size;)
+    {
+        const uint64_t s = _bra_min(BRA_MAX_CHUNK_SIZE, data_size - i);
+
+        // read source chunk
+        if (fread(buf, sizeof(char), s, src->f) != s)
+        {
+            bra_io_file_read_error(src);
+            return false;
+        }
+
+        me->crc32  = bra_crc32c(buf, s, me->crc32);
+        i         += s;
+    }
+
+    return true;
+}
+
 bool bra_io_file_copy_file_chunks(bra_io_file_t* dst, bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me)
 {
     assert_bra_io_file_t(dst);

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -156,13 +156,16 @@ bool bra_io_file_read_footer(bra_io_file_t* f, bra_io_footer_t* bf_out);
 bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
 
 /**
- * @brief
+ * @brief Read data_size bytes from src in #BRA_MAX_CHUNK_SIZE chunks and update @p me->crc32.
+ *        The file must be positioned at the start of the entry's data. On success,
+ *        the stream is advanced by data_size bytes (positioned at the entry's trailing CRC32).
+ *        On error, logs and closes @p src via @ref bra_io_file_read_error().
  *
- * @param src
- * @param data_size
- * @param me
- * @retval true
- * @retval false
+ * @param src[in.out]    input file wrapper (advanced by data_size on success; closed on error).
+ * @param data_size[in]  number of bytes to read from the current position.
+ * @param me[in,out]     metadata entry whose crc32 field is updated (must not be @c NULL).
+ * @retval true          on success
+ * @retval false         on error ( @p src is closed)
  */
 bool bra_io_file_read_file_chunks(bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me);
 

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -156,6 +156,18 @@ bool bra_io_file_read_footer(bra_io_file_t* f, bra_io_footer_t* bf_out);
 bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
 
 /**
+ * @brief Read a chunk of data from the source file.
+ *
+ * @param src      Source file wrapper.
+ * @param buf      Buffer to read data into.
+ * @param buf_size Size of the buffer.
+ * @param me       Metadata entry whose crc32 field is updated (must not be @c NULL).
+ * @retval true    On success.
+ * @retval false   On error. ( @p src is closed)
+ */
+bool bra_io_file_read_chunk(bra_io_file_t* src, void* buf, const size_t buf_size, bra_meta_entry_t* me);
+
+/**
  * @brief Read data_size bytes from src in #BRA_MAX_CHUNK_SIZE chunks and update @p me->crc32.
  *        The file must be positioned at the start of the entry's data. On success,
  *        the stream is advanced by data_size bytes (positioned at the entry's trailing CRC32).

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -156,6 +156,17 @@ bool bra_io_file_read_footer(bra_io_file_t* f, bra_io_footer_t* bf_out);
 bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
 
 /**
+ * @brief
+ *
+ * @param src
+ * @param data_size
+ * @param me
+ * @retval true
+ * @retval false
+ */
+bool bra_io_file_read_file_chunks(bra_io_file_t* src, const uint64_t data_size, bra_meta_entry_t* me);
+
+/**
  * @brief Copy from @p src to @p dst in chunks size of #BRA_MAX_CHUNK_SIZE for @p data_size bytes
  *        the files must be positioned at the correct read/write offsets.
  *        On failure closes both @p dst and @p src via @ref bra_io_file_close

--- a/src/io/lib_bra_io_file.h
+++ b/src/io/lib_bra_io_file.h
@@ -161,7 +161,7 @@ bool bra_io_file_write_footer(bra_io_file_t* f, const int64_t header_offset);
  *        the stream is advanced by data_size bytes (positioned at the entry's trailing CRC32).
  *        On error, logs and closes @p src via @ref bra_io_file_read_error().
  *
- * @param src[in.out]    input file wrapper (advanced by data_size on success; closed on error).
+ * @param src[in,out]    input file wrapper (advanced by data_size on success; closed on error).
  * @param data_size[in]  number of bytes to read from the current position.
  * @param me[in,out]     metadata entry whose crc32 field is updated (must not be @c NULL).
  * @retval true          on success

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -844,6 +844,7 @@ bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx, const bool test_mo
 
     char             bytes[BRA_PRINTF_FMT_BYTES_BUF_SIZE];
     bra_meta_entry_t me = {0};
+    char*            fn = NULL;
 
     if (!bra_io_file_ctx_read_meta_entry(ctx, &me))
         goto BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR;
@@ -851,7 +852,8 @@ bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx, const bool test_mo
     const uint64_t ds   = BRA_ATTR_TYPE(me.attributes) == BRA_ATTR_TYPE_FILE ? ((bra_meta_entry_file_t*) me.entry_data)->data_size : 0;
     const char     attr = bra_format_meta_attributes(me.attributes);
     size_t         len  = 0;
-    char*          fn   = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, &len);
+
+    fn = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, &len);
     if (fn == NULL)
         goto BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR;
 
@@ -944,6 +946,7 @@ BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR:
         free(fn);
         fn = NULL;
     }
+
     bra_meta_entry_free(&me);
     return false;
 }

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -17,6 +17,14 @@ static const char* g_attr_type_names[] = {"file", "dir", "symlink", "subdir"};
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @brief Reconstructs the full path of a meta entry.
+ *
+ * @param ctx The file context.
+ * @param me  The meta entry.
+ * @param len The length of the reconstructed path.
+ * @return char* The reconstructed path or NULL on failure.
+ */
 static char* _bra_io_file_ctx_reconstruct_meta_entry_name(bra_io_file_ctx_t* ctx, bra_meta_entry_t* me, size_t* len)
 {
     assert_bra_io_file_cxt_t(ctx);
@@ -868,11 +876,10 @@ bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx, const bool test_mo
 
         // duplicated block from decode
         // refactor in a function
-        const size_t fn_len = strlen(fn);
-        if (!_bra_validate_filename(fn, fn_len))
+        if (!_bra_validate_filename(fn, len))
             goto BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR;
 
-        if (!_bra_compute_header_crc32(fn_len, fn, &me))
+        if (!_bra_compute_header_crc32(len, fn, &me))
             goto BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR;
 
         // miss to read file content if it is a file otherwise crc32 is already computed

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -408,7 +408,7 @@ static inline bool _bra_io_file_ctx_compute_crc32(bra_io_file_ctx_t* ctx, const 
         break;
     }
 
-    return false;
+    return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -754,12 +754,12 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
         goto BRA_IO_DECODE_ERR;
 
     // the full path name
-    fn = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, NULL);
+    const size_t fn_len = strlen(fn);
+    fn                  = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, NULL);
     if (fn == NULL)
         goto BRA_IO_DECODE_ERR;
 
-    bool         skip_entry = false;
-    const size_t fn_len     = strlen(fn);
+    bool skip_entry = false;
     if (!_bra_validate_filename(fn, fn_len))
         goto BRA_IO_DECODE_ERR;
 
@@ -782,10 +782,8 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
 
             // skip file contents & crc32 too
             if (!bra_io_file_skip_data(&ctx->f, ds + sizeof(uint32_t)))
-            {
-                bra_io_file_seek_error(&ctx->f);
                 goto BRA_IO_DECODE_ERR;
-            }
+
             skip_entry = true;
         }
         else
@@ -905,10 +903,7 @@ bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx, const bool test_mo
     else
     {
         if (!bra_io_file_skip_data(&ctx->f, ds))
-        {
-            bra_io_file_seek_error(&ctx->f);
             goto BRA_IO_FILE_CTX_PRINT_META_ENTRY_ERR;
-        }
     }
 
     // read CRC32

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -622,12 +622,14 @@ bool bra_io_file_ctx_read_meta_entry(bra_io_file_ctx_t* ctx, bra_meta_entry_t* m
     buf[buf_size] = '\0';
 
     if (!bra_meta_entry_init(me, attr, buf, buf_size))
+    {
+        bra_log_error("unable to init meta entry for %s", buf);
         return false;
+    }
 
     // 4. entry data
     switch (BRA_ATTR_TYPE(me->attributes))
     {
-
     case BRA_ATTR_TYPE_SUBDIR:
     {
         assert(me->entry_data != NULL);

--- a/src/io/lib_bra_io_file_ctx.c
+++ b/src/io/lib_bra_io_file_ctx.c
@@ -756,12 +756,12 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
         goto BRA_IO_DECODE_ERR;
 
     // the full path name
-    const size_t fn_len = strlen(fn);
-    fn                  = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, NULL);
+    fn = _bra_io_file_ctx_reconstruct_meta_entry_name(ctx, &me, NULL);
     if (fn == NULL)
         goto BRA_IO_DECODE_ERR;
 
-    bool skip_entry = false;
+    const size_t fn_len     = strlen(fn);
+    bool         skip_entry = false;
     if (!_bra_validate_filename(fn, fn_len))
         goto BRA_IO_DECODE_ERR;
 

--- a/src/io/lib_bra_io_file_ctx.h
+++ b/src/io/lib_bra_io_file_ctx.h
@@ -136,10 +136,11 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
  * @note In non @c NDEBUG builds, also prints the last directory, @c ctx->last_dir, for debugging.
  *
  * @param ctx Archive context whose meta will be printed.
+ * @param test_mode If true, the function will also perform the CRC checks. if false, it will just print the entries.
  * @retval true
  * @retval false
  */
-bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx);
+bool bra_io_file_ctx_print_meta_entry(bra_io_file_ctx_t* ctx, const bool test_mode);
 
 #ifdef __cplusplus
 }

--- a/src/io/lib_bra_io_file_ctx.h
+++ b/src/io/lib_bra_io_file_ctx.h
@@ -135,8 +135,10 @@ bool bra_io_file_ctx_decode_and_write_to_disk(bra_io_file_ctx_t* ctx, bra_fs_ove
  *
  * @note In non @c NDEBUG builds, also prints the last directory, @c ctx->last_dir, for debugging.
  *
- * @param ctx Archive context whose meta will be printed.
- * @param test_mode If true, the function will also perform the CRC checks. if false, it will just print the entries.
+ * @param ctx       Archive context whose meta will be printed.
+ * @param test_mode If true, recomputes and verifies the entry CRC32 (reading file content when needed)
+ *                  and returns false on mismatch; if false, prints the entry and skips its data without verification.
+ *                  In both cases, the stream ends positioned just after the entry's CRC32.
  * @retval true
  * @retval false
  */

--- a/src/lib_bra.h
+++ b/src/lib_bra.h
@@ -93,6 +93,7 @@ bool bra_meta_entry_file_init(bra_meta_entry_t* me, const uint64_t data_size);
  */
 bool bra_meta_entry_subdir_init(bra_meta_entry_t* me, const uint32_t parent_index);
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib_bra_private.h
+++ b/src/lib_bra_private.h
@@ -52,3 +52,14 @@ bool _bra_validate_filename(const char* fn, const size_t fn_size);
  * @param max_length    Field width; if buf_length > max_length, prints max_length-3 chars + "...".
  */
 void _bra_print_string_max_length(const char* buf, const int buf_length, const int max_length);
+
+/**
+ * @brief Compute the CRC32C checksum for the header of a metadata entry.
+ *
+ * @param filename_len Length of the filename.
+ * @param filename     Pointer to the filename string.
+ * @param me           Pointer to the metadata entry.
+ * @retval true
+ * @retval false
+ */
+bool _bra_compute_header_crc32(const size_t filename_len, const char* filename, bra_meta_entry_t* me);

--- a/src/prog/unbra.cpp
+++ b/src/prog/unbra.cpp
@@ -200,6 +200,9 @@ protected:
                 if (!bra_io_file_ctx_print_meta_entry(&m_ctx, m_testContent))
                     return 2;
             }
+
+            if (m_testContent)
+                bra_log_printf("* All %u entr%s verified successfully.\n", bh.num_files, bh.num_files == 1 ? "y" : "ies");
         }
         else
         {
@@ -209,9 +212,6 @@ protected:
                 bra_log_printf("Creating output path: %s\n", m_output_path.string().c_str());
                 if (!bra::fs::dir_make(m_output_path))
                     return 1;
-
-                if (m_testContent)
-                    bra_log_printf("* All %u entr%s verified successfully.\n", bh.num_files, bh.num_files == 1 ? "y" : "ies");
             }
             const fs::path cur_path = fs::current_path(ec);
             if (ec)

--- a/src/prog/unbra.cpp
+++ b/src/prog/unbra.cpp
@@ -209,6 +209,9 @@ protected:
                 bra_log_printf("Creating output path: %s\n", m_output_path.string().c_str());
                 if (!bra::fs::dir_make(m_output_path))
                     return 1;
+
+                if (m_testContent)
+                    bra_log_printf("* All %u entr%s verified successfully.\n", bh.num_files, bh.num_files == 1 ? "y" : "ies");
             }
             const fs::path cur_path = fs::current_path(ec);
             if (ec)
@@ -236,6 +239,7 @@ protected:
         }
 
         bra_io_file_ctx_close(&m_ctx);
+
         return 0;
     }
 

--- a/src/prog/unbra.cpp
+++ b/src/prog/unbra.cpp
@@ -34,6 +34,7 @@ private:
     fs::path m_bra_file;
     fs::path m_output_path;
     bool     m_listContent = false;
+    bool     m_testContent = false;
     bool     m_sfx         = false;
 
 protected:
@@ -53,6 +54,7 @@ protected:
     virtual void help_options() const override
     {
         bra_log_printf("--list       | -l : view archive content.\n");
+        bra_log_printf("--test       | -t : test archive integrity (implies --list).\n");
         bra_log_printf("--output     | -o : output path: must be a directory relative to the current one (default: current directory).\n");
     };
 
@@ -63,6 +65,12 @@ protected:
         if (s == "--list" || s == "-l")
         {
             // list content
+            m_listContent = true;
+        }
+        else if (s == "--test" || s == "-t")
+        {
+            // test content
+            m_testContent = true;
             m_listContent = true;
         }
         else if (s == "--output" || s == "-o")
@@ -180,7 +188,7 @@ protected:
         }
 
         bra_log_printf("%s contains num files: %u\n", m_ctx.f.fn, bh.num_files);
-        if (m_listContent)
+        if (m_listContent || m_testContent)
         {
             bra_log_printf("| ATTR |   SIZE    | " BRA_PRINTF_FMT_FILENAME "| CRC32  |\n", "FILENAME");
             bra_log_printf("|------|-----------|-");
@@ -189,7 +197,7 @@ protected:
             bra_log_printf("|--------|\n");
             for (uint32_t i = 0; i < bh.num_files; i++)
             {
-                if (!bra_io_file_ctx_print_meta_entry(&m_ctx))
+                if (!bra_io_file_ctx_print_meta_entry(&m_ctx, m_testContent))
                     return 2;
             }
         }

--- a/test/test_bra.cpp
+++ b/test/test_bra.cpp
@@ -311,7 +311,7 @@ TEST(test_bra_not_more_than_1_same_file)
 TEST(test_bra_unbra_all)
 {
     const std::string bra      = CMD_PREFIX + "bra -r";
-    const std::string unbra    = CMD_PREFIX + "unbra -l";
+    const std::string unbra    = CMD_PREFIX + "unbra -t";
     const std::string in_file  = "*";
     const std::string out_file = "./all.BRa";
 


### PR DESCRIPTION
- [x] add a runtime test with--test bra/unbra 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a --test (-t) option to verify archive contents without extracting; enables listing and performs chunked reads with progressive CRC validation, reporting mismatches.
- **Documentation**
  - Help text updated to document the new testing option and its interaction with listing.
- **Bug Fixes**
  - Improved error handling, reporting, and cleanup for read/seek and CRC validation failures.
- **Tests**
  - Updated tests to exercise the new test-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->