### PR TITLE
Add more CRC32C tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(test_bra_crc32c PRIVATE lib_bra)
 
 add_test(NAME test_bra_crc32c.compute_crc32         COMMAND test_bra_crc32c test_bra_crc32c_compute_crc32)
 add_test(NAME test_bra_crc32c.empty_input           COMMAND test_bra_crc32c test_bra_crc32c_empty_input)
+add_test(NAME test_bra_crc32c.table_compute_crc32   COMMAND test_bra_crc32c test_bra_crc32c_table_compute_crc32)
 
 ### SSE4.2 specific tests (only on x86_64/AMD64/i386)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|i[3-6]86")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded CRC32C coverage to include the table-based computation path alongside SSE4.2.
  - Added cases for empty and null inputs, plus multiple data sets with expected CRCs.
  - Introduced shared test constants to reduce duplication and improve clarity.
  - Added consistency checks between table and SSE4.2 implementations across varying lengths.
  - Registered a new test in the suite to execute the table-based path via the test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->